### PR TITLE
Implement I2C Transaction Timeouts

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -14,7 +14,8 @@ framework = arduino
 board = atmega328p
 build_flags = 
     -D VERBOSE 
-    -D CHIPSAT_ID=2
+    -D WIRE_TIMEOUT
+    -D CHIPSAT_ID=3
 upload_protocol = custom
 upload_speed = 19200
-upload_command = avrdude -C /Users/camerongoddard/Library/Arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf -P /dev/cu.usbmodem11301 -b 19200 -v -V -p atmega328p -c stk500v1 $UPLOAD_FLAGS -U flash:w:$SOURCE:i
+upload_command = avrdude -C /Users/camerongoddard/Library/Arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf -P /dev/cu.usbmodem211301 -b 19200 -v -V -p atmega328p -c stk500v1 $UPLOAD_FLAGS -U flash:w:$SOURCE:i

--- a/src/Monitors/IMUMonitor.cpp
+++ b/src/Monitors/IMUMonitor.cpp
@@ -1,6 +1,6 @@
 #include "IMUMonitor.hpp"
 
-IMUMonitor::IMUMonitor(): imu(Wire)
+IMUMonitor::IMUMonitor() : imu(Wire)
 {
 }
 

--- a/src/Monitors/IMUMonitor.cpp
+++ b/src/Monitors/IMUMonitor.cpp
@@ -1,6 +1,6 @@
 #include "IMUMonitor.hpp"
 
-IMUMonitor::IMUMonitor()
+IMUMonitor::IMUMonitor(): imu(Wire)
 {
 }
 
@@ -10,7 +10,7 @@ void IMUMonitor::execute()
 #ifdef VERBOSE
         Serial.println(F("Turning on IMU"));
 #endif
-        if (!IMU.begin()) {
+        if (!imu.begin()) {
 #ifdef VERBOSE
             Serial.println(F("IMU failed"));
 #endif
@@ -26,22 +26,22 @@ void IMUMonitor::execute()
 void IMUMonitor::capture_imu_values()
 {
     // Check if the gyroscope, accelerometer, or magnetometer has new data available
-    if (IMU.gyroscopeAvailable()) {
-        IMU.readGyroscope(
+    if (imu.gyroscopeAvailable()) {
+        imu.readGyroscope(
             sfr::imu::gyro_x,
             sfr::imu::gyro_y,
             sfr::imu::gyro_z); // Data is in degrees/s
     }
 
-    if (IMU.accelerationAvailable()) {
-        IMU.readAcceleration(
+    if (imu.accelerationAvailable()) {
+        imu.readAcceleration(
             sfr::imu::acc_x,
             sfr::imu::acc_y,
             sfr::imu::acc_z); // Data is in m/s^2
     }
 
-    if (IMU.magneticFieldAvailable()) {
-        IMU.readMagneticField(
+    if (imu.magneticFieldAvailable()) {
+        imu.readMagneticField(
             sfr::imu::mag_x,
             sfr::imu::mag_y,
             sfr::imu::mag_z); // Data in uT

--- a/src/Monitors/IMUMonitor.hpp
+++ b/src/Monitors/IMUMonitor.hpp
@@ -19,6 +19,8 @@ private:
      * @brief Reads IMU data
      */
     void capture_imu_values();
+
+    LSM9DS1Class imu;
 };
 
 #endif

--- a/src/Monitors/TempMonitor.cpp
+++ b/src/Monitors/TempMonitor.cpp
@@ -2,8 +2,6 @@
 
 TempMonitor::TempMonitor()
 {
-    // Init I2C communication as master
-    Wire.begin();
 }
 
 void TempMonitor::execute()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -12,6 +12,10 @@ void setup()
     Serial.begin(9600);
 #endif
 
+    // Set I2C transaction timeout
+    Wire.begin();
+    Wire.setWireTimeout(3000);
+
     sfr::gps::boot_time = millis();
 
     // Set ChipSat LED high for debugging


### PR DESCRIPTION
Add in timeouts to the Wire library and define WIRE_TIMEOUT in the PlatformIO config. I set a timeout of 3000 microseconds (3 milliseconds), which seems reasonable but could be discussed further. Tested with an IMU breakout.